### PR TITLE
Update link to point to transaction signer

### DIFF
--- a/bounties/level-2/stellar-lab-albedo.md
+++ b/bounties/level-2/stellar-lab-albedo.md
@@ -37,6 +37,6 @@ The developer should provide a completed fork of the laboratory implementing new
 
 ## Links
  - https://github.com/stellar/laboratory
- - https://laboratory.stellar.org/#txbuilder
+ - https://laboratory.stellar.org/#txsigner
 
 


### PR DESCRIPTION
In the links-section the txbuilder was references whereas this change mainly will go on the txsigner page