### PR TITLE
Implement tracking issue GitHub action and add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+Thank you for your submission.  
+*Please mention the tracking issue for your bounty in the title!*  
+If your submission is not completed yet please make sure to create this pull request as a "draft"  (You can change this at any time).
+
+----
+
+## What bounty did you solve?
+_Please mention the solved bounty tracking issue here:_  
+_I created a solution for:_ #...
+
+## Payment address
+_Which account should the reward be sent to?_  
+`G...`
+
+----
+## Anything else?
+_Is there anything else the reviewers should know?_

--- a/.github/workflows/tracking-issue.yaml
+++ b/.github/workflows/tracking-issue.yaml
@@ -1,0 +1,48 @@
+name: Create Tracking issue
+on: 
+  push:
+    branches:
+      - master
+      - main
+    paths:
+      - 'bounties/*/*.md'    # include all possible markdown files in subdirs
+      - '!bounties/*/_*.md'  # remove all markdown files prefixed with _ as those are tempoary.
+
+jobs:
+  create_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v9
+        with:
+          files: bounties\/.+\/[A-Za-z0-9\-]+.md   # match bounties/**/[A-Za-z0-9]+.md
+      - name: Create Tracking Issues
+        shell: bash
+        run: |
+          echo "Processing ${{ steps.changed-files.outputs.all_modified_files }}"
+          str="${{ steps.changed-files.outputs.all_modified_files }}"
+          arr=($str)
+          for file in "${arr[@]}"; do
+            export bounty="$(echo $file | cut -c 10-)" # cut off first dir
+            echo "$file -> $bounty"
+            export name="[Tracking] \`$bounty\`"
+            # check for existing issues with this name
+            export upstream_issue=$(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ github.repository }}/issues | jq ".[] | select(.pull_request==null) | select(.title == \"$name\")")
+            if [ "$upstream_issue" == "" ]; then
+              # submit new issue
+              curl --request POST \
+              -s \
+              --url https://api.github.com/repos/${{ github.repository }}/issues \
+              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+              --header 'content-type: application/json' \
+              --data "{
+                \"title\": \"$name\",
+                \"body\": \"This issue is tracking [$bounty]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blob/${GITHUB_REF#refs/heads/}/$file)\"
+                }" \
+              --fail
+            fi
+          done          


### PR DESCRIPTION
Add GitHub action to automatically create tracking issue for newly accepted bounty proposals.
Add PR template for completed bounty submissions.

Tracking issues will be in the format `[Tracking] filename`

Potential issues:

If commit contains renaming an existing proposal, the GitHub action will create a new tracking issue instead of renaming the old.

Possible TODO:

Automatically assign labels to tracking issues. 