### PR TITLE
Fix/add list-bounties and create-bounties links in active specs

### DIFF
--- a/bounties/level-1/basic-account-viewer.md
+++ b/bounties/level-1/basic-account-viewer.md
@@ -5,8 +5,9 @@
 | :- | :- | :-
 | 800 XLM | 2 Credits | Continuos
 
-📜&nbsp; View [existing submissions](https://github.com/tyvdh/stellar-quest-bounties/issues?q=basic-account-viewer.md) for this bounty. \
+📜&nbsp; View [existing submissions](https://github.com/tyvdh/stellar-quest-bounties/issues?q=is%3Aissue+basic-account-viewer) for this bounty. \
 🔵&nbsp; Start [hunting](https://github.com/tyvdh/stellar-quest-bounties/issues/new?assignees=&labels=&template=begin-the-hunt.yml&title=%F0%9F%94%B5+%60basic-account-viewer.md%60) this bounty.
+
 ## Description
 
 ### What is this task?

--- a/bounties/level-1/create-bounties.md
+++ b/bounties/level-1/create-bounties.md
@@ -6,7 +6,7 @@
 | 200 XLM per submission | 0 Credits | Continuous
 
 📜&nbsp; View [existing submissions](https://github.com/tyvdh/stellar-quest-bounties/issues?q=is%3Aissue+create-bounties+) for this bounty. \
-🔵&nbsp; Suggest [a new](https://github.com/tyvdh/stellar-quest-bounties/issues/new?assignees=&labels=&template=begin-the-hunt.md&title=%F0%9F%94%B5+%60create-bounties.md%60) bounty.
+🔵&nbsp; Suggest [a new](https://github.com/tyvdh/stellar-quest-bounties/issues/new?assignees=&labels=&template=begin-the-hunt.yml&title=%F0%9F%94%B5+%60create-bounties.md%60) bounty.
 
 ## Description
 

--- a/bounties/level-1/stellar-docs-code-snippet.md
+++ b/bounties/level-1/stellar-docs-code-snippet.md
@@ -4,6 +4,9 @@
 | :- | :-
 | 50 XLM per example | 0 Credits (success will be determined by PR acceptance by the SDF docs maintainers)
 
+📜&nbsp; View [existing submissions](https://github.com/tyvdh/stellar-quest-bounties/issues?q=is%3Aissue+stellar-docs-code-snippet) for this bounty. \
+🔵&nbsp; Start [hunting](https://github.com/tyvdh/stellar-quest-bounties/issues/new?assignees=&labels=&template=begin-the-hunt.yml&title=%F0%9F%94%B5+%60stellar-docs-code-snippet.md%60) this bounty.
+
 ## Description
 
 ### What is this task?

--- a/bounties/level-2/million-lumen-homepage.md
+++ b/bounties/level-2/million-lumen-homepage.md
@@ -5,6 +5,9 @@
 | :- | :-
 | 2000 XLM | 4 Credits
 
+📜&nbsp; View [existing submissions](https://github.com/tyvdh/stellar-quest-bounties/issues?q=is%3Aissue+million-lumen-homepage) for this bounty. \
+🔵&nbsp; Start [hunting](https://github.com/tyvdh/stellar-quest-bounties/issues/new?assignees=&labels=&template=begin-the-hunt.yml&title=%F0%9F%94%B5+%60million-lumen-homepage.md%60) this bounty.
+
 ## Description
 
 ### What is this task?

--- a/bounties/level-2/stellar-quest-badge-checker.md
+++ b/bounties/level-2/stellar-quest-badge-checker.md
@@ -4,6 +4,9 @@
 | :- | :-
 | 3500 XLM | 6 Credits
 
+📜&nbsp; View [existing submissions](https://github.com/tyvdh/stellar-quest-bounties/issues?q=is%3Aissue+stellar-quest-badge-checker) for this bounty. \
+🔵&nbsp; Start [hunting](https://github.com/tyvdh/stellar-quest-bounties/issues/new?assignees=&labels=&template=begin-the-hunt.yml&title=%F0%9F%94%B5+%60stellar-quest-badge-checker.md%60) this bounty.
+
 ## Description
 
 Being a Stellar Quester comes with perks, however the perks are only as claimable as the proof you have of your Stellar Quest account. To this end we're looking for an interesting, innovative web application for proving original ownership of Stellar Quest badges.


### PR DESCRIPTION
Some of the specs have been missing the new links

![grafik](https://user-images.githubusercontent.com/1752217/128289212-39156eb4-7d8c-4de0-a1cc-f4157c61cef7.png)

* Added missing links to make active specs match the template
* Checked existing links to make use of the new issue-form