### PR TITLE
Add workflow to manage labels according to issue state

### DIFF
--- a/.github/ISSUE_TEMPLATE/begin-the-hunt.yml
+++ b/.github/ISSUE_TEMPLATE/begin-the-hunt.yml
@@ -11,17 +11,16 @@ body:
     validations:
       required: true
 
-  - type: textarea
+  - type: checkboxes
     id: progress
     attributes:
       label: Mark your progress
-      description: Please remember to mark **_and update_** the prefix of the title of this issue with one of the following emojis.
-      value: |
-        - [x] 🔵&nbsp; Started working
-        - [ ] 🟢&nbsp; Ready for review
-        - [ ] 🟣&nbsp; Review completed
-    validations:
-      required: true
+      description: Select the blue emoji (**required**) to mark your issue as started
+      options:
+        - label: 🔵&nbsp; Started working
+          required: true
+        - label: 🟢&nbsp; Ready for review
+        - label: 🟣&nbsp; Review completed
 
   - type: textarea
     id: details

--- a/.github/workflows/label_bounty_hunter_issues.yml
+++ b/.github/workflows/label_bounty_hunter_issues.yml
@@ -1,0 +1,76 @@
+name: Bounty hunter issue progress automation
+
+on:
+  issues: 
+    types: [opened, edited]
+
+jobs:
+  issue_commented:
+    name: "Map issue progress to labels"
+    if: ${{ !github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
+      # check for progress check-boxes
+      - name: Check if 'claimed' is checkd
+        uses: actions-ecosystem/action-regex-match@v2
+        id: check-claimed
+        with:
+          text: ${{ github.event.issue.body }}
+          regex: '- \[(.{1})\] \ud83d\udd35'
+      - name: Check if 'ready for review' is checkd
+        uses: actions-ecosystem/action-regex-match@v2
+        id: check-ready-for-review
+        with:
+          text: ${{ github.event.issue.body }}
+          regex: '- \[(.{1})\] \ud83d\udfe2'
+      - name: Check if 'review done' is checkd
+        uses: actions-ecosystem/action-regex-match@v2
+        id: check-review-done
+        with:
+          text: ${{ github.event.issue.body }}
+          regex: '- \[(.{1})\] \ud83d\udfe3'
+
+      # remove labels for unchecked boxes
+      - name: remove claimed label
+        uses: actions-ecosystem/action-remove-labels@v1
+        if: ${{ steps.check-ready-for-review.outputs.group1 == 'x' || steps.check-review-done.outputs.group1 == 'x' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: bounty claimed
+      - name: remove ready for review label
+        uses: actions-ecosystem/action-remove-labels@v1
+        if: ${{ steps.check-claimed.outputs.group1 == ' ' || steps.check-review-done.outputs.group1 == 'x' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: bounty ready for review
+      - name: remove review done label
+        uses: actions-ecosystem/action-remove-labels@v1
+        if: ${{ steps.check-claimed.outputs.group1 == ' ' || steps.check-ready-for-review.outputs.group1 == ' ' || steps.check-review-done.outputs.group1 == ' ' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: bounty reviewed
+      
+      # add label according to progress
+      - name: add claimed label
+        uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ steps.check-claimed.outputs.group1 == 'x' && steps.check-ready-for-review.outputs.group1 == ' ' && steps.check-review-done.outputs.group1 == ' ' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: bounty claimed
+      - name: add waiting for review label
+        uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ steps.check-claimed.outputs.group1 == 'x' && steps.check-ready-for-review.outputs.group1 == 'x' && steps.check-review-done.outputs.group1 == ' ' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: bounty ready for review
+      - name: add review done label
+        uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ steps.check-claimed.outputs.group1 == 'x' && steps.check-ready-for-review.outputs.group1 == 'x' && steps.check-review-done.outputs.group1 == 'x' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: bounty reviewed


### PR DESCRIPTION
This is a poor-mans approach to manage labels in issues according to check-boxes introduced with the new issues-template
![grafik](https://user-images.githubusercontent.com/1752217/128479468-d48ceb9c-7628-46a8-963d-ae3bedac09cc.png)

Existing progress-related labels will be deleted so that only one progress label is attached. I.e. when the issue transitions from _started working_ to _ready for review_ by checking the second checkbox, the _started working_ label will be **removed** and the _ready for review_ label will be **added**.