### PR TITLE
Add workflow to set issue title based on selected bounty-spec filename

### DIFF
--- a/.github/ISSUE_TEMPLATE/begin-the-hunt.yml
+++ b/.github/ISSUE_TEMPLATE/begin-the-hunt.yml
@@ -1,6 +1,6 @@
 name: Begin The Hunt!
 description: Use when beginning a new bounty hunt
-title: "\U0001F535 `<title-of-bounty-file>.md`"
+title: "Bounty hunt"
 body:
   - type: input
     id: link

--- a/.github/ISSUE_TEMPLATE/begin-the-hunt.yml
+++ b/.github/ISSUE_TEMPLATE/begin-the-hunt.yml
@@ -1,6 +1,5 @@
 name: Begin The Hunt!
 description: Use when beginning a new bounty hunt
-title: "Bounty hunt"
 body:
   - type: input
     id: link

--- a/.github/workflows/manage_title.yml
+++ b/.github/workflows/manage_title.yml
@@ -1,0 +1,33 @@
+name: Bounty hunter issue title management
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  extract_filename_from_path:
+    name: "Generate the title from the filename"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get the spec filename
+        uses: actions-ecosystem/action-regex-match@v2
+        id: match-spec-filename
+        with:
+          text: ${{ github.event.issue.body }}
+          regex: '^\s*https:\/\/github\.com\/.*\/bounties\/level-([\d])+\/(.*\.md)$'
+          flags: m
+      - name: Add spec filename to title
+        uses: actions-cool/issues-helper@v2.2.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          actions: 'update-issue'
+          update-mode: 'replace'
+          title: "`${{ steps.match-spec-filename.outputs.group2 }}` ${{ github.event.issue.title }}"
+      - name: Add label for bounty level
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            bounty
+            level ${{ steps.match-spec-filename.outputs.group1 }}

--- a/.github/workflows/manage_title.yml
+++ b/.github/workflows/manage_title.yml
@@ -1,4 +1,4 @@
-name: Bounty hunter issue title management
+name: Bounty hunter issue label assignment management
 
 on:
   issues:

--- a/.github/workflows/manage_title.yml
+++ b/.github/workflows/manage_title.yml
@@ -14,16 +14,8 @@ jobs:
         id: match-spec-filename
         with:
           text: ${{ github.event.issue.body }}
-          regex: '^\s*https:\/\/github\.com\/.*\/bounties\/level-([\d])+\/(.*\.md)$'
+          regex: '^\s*https:\/\/github\.com\/.*\/bounties\/level-([\d])+\/(.*)\.md$'
           flags: m
-      - name: Add spec filename to title
-        uses: actions-cool/issues-helper@v2.2.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          actions: 'update-issue'
-          update-mode: 'replace'
-          title: "`${{ steps.match-spec-filename.outputs.group2 }}` ${{ github.event.issue.title }}"
       - name: Add label for bounty level
         uses: actions-ecosystem/action-add-labels@v1
         with:
@@ -31,3 +23,4 @@ jobs:
           labels: |
             bounty
             level ${{ steps.match-spec-filename.outputs.group1 }}
+            ${{ steps.match-spec-filename.outputs.group2 }}

--- a/bounties/README.md
+++ b/bounties/README.md
@@ -6,8 +6,8 @@
 | {x} XLM | {x} XLM | Capped ({x}) \| Continuos \| Competitive
 
 [//]: # (make sure to replace the file-name placeholder '{bounty-file-name}' in the next two lines with the actual filename)
-📜&nbsp; View [existing submissions](https://github.com/tyvdh/stellar-quest-bounties/issues?q=is%3Aissue+%7Bbounty-file-name%7D+) for this bounty. \
-🔵&nbsp; Start [hunting](https://github.com/tyvdh/stellar-quest-bounties/issues/new?assignees=&labels=&template=begin-the-hunt.yml&title=%F0%9F%94%B5+%60%3Cbounty-file-name%3E.md%60) this bounty.
+📜&nbsp; View [existing submissions](https://github.com/tyvdh/stellar-quest-bounties/issues?q=is%3Aissue+label%3A%3CBOUNTY_FILE_NAME_NO_EXTENSION%3E) for this bounty. \
+🔵&nbsp; Start [hunting](https://github.com/tyvdh/stellar-quest-bounties/issues/new?assignees=&labels=&template=begin-the-hunt.yml&link=https://github.com/tyvdh/stellar-quest-bounties/blob/main/bounties/level-%3CLEVEL%3E/%3CBOUNTY_FILE_NAME_WITH_EXTENSION%3E) this bounty.
 
 ## Description
 

--- a/bounties/level-1/basic-account-viewer.md
+++ b/bounties/level-1/basic-account-viewer.md
@@ -4,8 +4,8 @@
 | :- | :- | :-
 | 800 XLM | 400 XLM | Continuos
 
-📜&nbsp; View [existing submissions](https://github.com/tyvdh/stellar-quest-bounties/issues?q=is%3Aissue+basic-account-viewer) for this bounty. \
-🔵&nbsp; Start [hunting](https://github.com/tyvdh/stellar-quest-bounties/issues/new?assignees=&labels=&template=begin-the-hunt.yml&title=%F0%9F%94%B5+%60basic-account-viewer.md%60) this bounty.
+📜&nbsp; View [existing submissions](https://github.com/tyvdh/stellar-quest-bounties/issues?q=is%3Aissue+label%3Abasic-account-viewer) for this bounty. \
+🔵&nbsp; Start [hunting](https://github.com/tyvdh/stellar-quest-bounties/issues/new?assignees=&labels=&template=begin-the-hunt.yml&link=https://github.com/tyvdh/stellar-quest-bounties/blob/main/bounties/level-1/basic-account-viewer.md) this bounty.
 
 ## Description
 

--- a/bounties/level-1/create-bounties.md
+++ b/bounties/level-1/create-bounties.md
@@ -4,8 +4,8 @@
 | :- | :- | :-
 | 200 XLM per submission | N/A (success will be determined by PR acceptance) | Continuous
 
-📜&nbsp; View [existing submissions](https://github.com/tyvdh/stellar-quest-bounties/issues?q=is%3Aissue+create-bounties+) for this bounty. \
-🔵&nbsp; Suggest [a new](https://github.com/tyvdh/stellar-quest-bounties/issues/new?assignees=&labels=&template=begin-the-hunt.yml&title=%F0%9F%94%B5+%60create-bounties.md%60) bounty.
+📜&nbsp; View [existing submissions](https://github.com/tyvdh/stellar-quest-bounties/issues?q=is%3Aissue+label%3Acreate-bounties) for this bounty. \
+🔵&nbsp; Suggest [a new](https://github.com/tyvdh/stellar-quest-bounties/issues/new?assignees=&labels=&template=begin-the-hunt.yml&link=https://github.com/tyvdh/stellar-quest-bounties/blob/main/bounties/level-1/create-bounties.md) bounty.
 
 ## Description
 

--- a/bounties/level-1/stellar-docs-code-snippet.md
+++ b/bounties/level-1/stellar-docs-code-snippet.md
@@ -4,8 +4,8 @@
 | :- | :- | :-
 | 50 XLM per example | N/A (success will be determined by PR acceptance) | Competitive
 
-📜&nbsp; View [existing submissions](https://github.com/tyvdh/stellar-quest-bounties/issues?q=is%3Aissue+stellar-docs-code-snippet) for this bounty. \
-🔵&nbsp; Start [hunting](https://github.com/tyvdh/stellar-quest-bounties/issues/new?assignees=&labels=&template=begin-the-hunt.yml&title=%F0%9F%94%B5+%60stellar-docs-code-snippet.md%60) this bounty.
+📜&nbsp; View [existing submissions](https://github.com/tyvdh/stellar-quest-bounties/issues?q=is%3Aissue+label%3Astellar-docs-code-snippet) for this bounty. \
+🔵&nbsp; Start [hunting](https://github.com/tyvdh/stellar-quest-bounties/issues/new?assignees=&labels=&template=begin-the-hunt.yml&link=https://github.com/tyvdh/stellar-quest-bounties/blob/main/bounties/level-1/stellar-docs-code-snippet.md) this bounty.
 
 ## Description
 

--- a/bounties/level-2/million-lumen-homepage.md
+++ b/bounties/level-2/million-lumen-homepage.md
@@ -4,8 +4,8 @@
 | :- | :- | :-
 | 2000 XLM | 800 XLM | Capped (3)
 
-📜&nbsp; View [existing submissions](https://github.com/tyvdh/stellar-quest-bounties/issues?q=is%3Aissue+million-lumen-homepage) for this bounty. \
-🔵&nbsp; Start [hunting](https://github.com/tyvdh/stellar-quest-bounties/issues/new?assignees=&labels=&template=begin-the-hunt.yml&title=%F0%9F%94%B5+%60million-lumen-homepage.md%60) this bounty.
+📜&nbsp; View [existing submissions](https://github.com/tyvdh/stellar-quest-bounties/issues?q=is%3Aissue+label%3Amillion-lumen-homepage) for this bounty. \
+🔵&nbsp; Start [hunting](https://github.com/tyvdh/stellar-quest-bounties/issues/new?assignees=&labels=&template=begin-the-hunt.yml&link=https://github.com/tyvdh/stellar-quest-bounties/blob/main/bounties/level-2/million-lumen-homepage.md) this bounty.
 
 ## Description
 

--- a/bounties/level-2/stellar-quest-badge-checker.md
+++ b/bounties/level-2/stellar-quest-badge-checker.md
@@ -4,8 +4,8 @@
 | :- | :- | :-
 | 3500 XLM | 1200 XLM | Capped (5)
 
-📜&nbsp; View [existing submissions](https://github.com/tyvdh/stellar-quest-bounties/issues?q=is%3Aissue+stellar-quest-badge-checker) for this bounty. \
-🔵&nbsp; Start [hunting](https://github.com/tyvdh/stellar-quest-bounties/issues/new?assignees=&labels=&template=begin-the-hunt.yml&title=%F0%9F%94%B5+%60stellar-quest-badge-checker.md%60) this bounty.
+📜&nbsp; View [existing submissions](https://github.com/tyvdh/stellar-quest-bounties/issues?q=is%3Aissue+label%3Astellar-quest-badge-checker) for this bounty. \
+🔵&nbsp; Start [hunting](https://github.com/tyvdh/stellar-quest-bounties/issues/new?assignees=&labels=&template=begin-the-hunt.yml&link=https://github.com/tyvdh/stellar-quest-bounties/blob/main/bounties/level-2/stellar-quest-badge-checker.md) this bounty.
 
 ## Description
 


### PR DESCRIPTION
When creating a new bounty issue the title will be automatically set the match the selected file:
![grafik](https://user-images.githubusercontent.com/1752217/128477850-0987758f-1ec6-4674-a1a0-199705b133a5.png)

⏬ 

![grafik](https://user-images.githubusercontent.com/1752217/128478188-823535b4-232c-4641-8bd8-c42d04c38d56.png)


This should only be merged **after** #84 because the color-emoji will not be in the title anymore