### PR TITLE
Replace url-encoded placeholder-brackets

### DIFF
--- a/bounties/README.md
+++ b/bounties/README.md
@@ -5,7 +5,7 @@
 | :- | :- | :-
 | {x} XLM | {x} XLM | Capped ({x}) \| Continuos \| Competitive
 
-[//]: # (make sure to replace the file-name placeholders `BOUNTY_FILE_NAME_NO_EXTENSION` and `BOUNTY_FILE_NAME_WITH_EXTENSION` in the next two lines with the actual bounty filename)
+[//]: # (make sure to replace the file-name placeholders `<BOUNTY_FILE_NAME_NO_EXTENSION>`, `<BOUNTY_FILE_NAME_WITH_EXTENSION> and `<LEVEL>` in the next two lines with the respective values)
 📜&nbsp; View [existing submissions](https://github.com/tyvdh/stellar-quest-bounties/issues?q=is%3Aissue+label%3A<BOUNTY_FILE_NAME_NO_EXTENSION>) for this bounty. \
 🔵&nbsp; Start [hunting](https://github.com/tyvdh/stellar-quest-bounties/issues/new?assignees=&labels=&template=begin-the-hunt.yml&link=https://github.com/tyvdh/stellar-quest-bounties/blob/main/bounties/level-<LEVEL>/<BOUNTY_FILE_NAME_WITH_EXTENSION>) this bounty.
 

--- a/bounties/README.md
+++ b/bounties/README.md
@@ -6,8 +6,8 @@
 | {x} XLM | {x} XLM | Capped ({x}) \| Continuos \| Competitive
 
 [//]: # (make sure to replace the file-name placeholders `BOUNTY_FILE_NAME_NO_EXTENSION` and `BOUNTY_FILE_NAME_WITH_EXTENSION` in the next two lines with the actual bounty filename)
-📜&nbsp; View [existing submissions](https://github.com/tyvdh/stellar-quest-bounties/issues?q=is%3Aissue+label%3A%3CBOUNTY_FILE_NAME_NO_EXTENSION%3E) for this bounty. \
-🔵&nbsp; Start [hunting](https://github.com/tyvdh/stellar-quest-bounties/issues/new?assignees=&labels=&template=begin-the-hunt.yml&link=https://github.com/tyvdh/stellar-quest-bounties/blob/main/bounties/level-%3CLEVEL%3E/%3CBOUNTY_FILE_NAME_WITH_EXTENSION%3E) this bounty.
+📜&nbsp; View [existing submissions](https://github.com/tyvdh/stellar-quest-bounties/issues?q=is%3Aissue+label%3A<BOUNTY_FILE_NAME_NO_EXTENSION>) for this bounty. \
+🔵&nbsp; Start [hunting](https://github.com/tyvdh/stellar-quest-bounties/issues/new?assignees=&labels=&template=begin-the-hunt.yml&link=https://github.com/tyvdh/stellar-quest-bounties/blob/main/bounties/level-<LEVEL>/<BOUNTY_FILE_NAME_WITH_EXTENSION>) this bounty.
 
 ## Description
 


### PR DESCRIPTION
As the pointy brackets (`<`, `>`) are part of the placeholder that needs to be replace with the actual value there is no need to url-encode them.

The urlencode rather hides them from the person starting a new bounty and such they might miss to remove them.